### PR TITLE
switch to getopt_long() to fix linking against musl

### DIFF
--- a/sunxi-fw.c
+++ b/sunxi-fw.c
@@ -132,13 +132,20 @@ static void usage(FILE *stream, const char *progname)
 
 int main(int argc, char **argv)
 {
+	const struct option longopts[] = {
+		{ .name = "name", .has_arg = required_argument, .val = 'n' },
+		{ .name = "output", .has_arg = required_argument, .val = 'o' },
+		{ .name = "help", .has_arg = no_argument, .val = 'h' },
+		{ .name = "verbose", .has_arg = no_argument, .val = 'v' },
+		{ .name = "all", .has_arg = no_argument, .val = 'a' },
+	};
 	FILE *inf, *outf = NULL;
 	int option;
 	char *action, *outfn = NULL;
 	char *name = NULL;
 	bool verbose = false, scan_all = false;
 
-	while ((option = getopt(argc, argv, "n:o:hva")) != -1) {
+	while ((option = getopt_long(argc, argv, "n:o:hva", longopts, NULL)) != -1) {
 		switch (option) {
 		case 'o':
 			outfn = optarg;


### PR DESCRIPTION
We don't really need long options, but using getopt_long(), which is a GNU extension, relaxes the strict requirements that the strict POSIX compliant musl implementation of getopt() has. This behaviour stops parsing when it finds the first non-option argument, which is our action verb. So any parameter afterwards (like -v) is ignored.

The glibc implementation of getopt() and all getopt_long() implementations shuffle argv and put option arguments first, so work as expected.

This fixes operation on musl based systems, or when compiling a static binary with musl.