### PR TITLE
boot0: rework to add heuristics to dram_para printing

### DIFF
--- a/sunxi-boot0.c
+++ b/sunxi-boot0.c
@@ -241,6 +241,105 @@ dram_param_a10_print(FILE *stream, void *raw)
 	fprintf(stream, "\n");
 }
 
+/*
+ * should work for A31 and relations
+ */
+#define DRAM_PARAM_A31_MATCHES "A31/A23/A33/A83T/A64/H3"
+
+struct dram_param_a31 {
+	uint32_t clk;
+	uint32_t type;
+	uint32_t zq;
+	uint32_t odt_en;
+	uint32_t para1;
+	uint32_t para2;
+	uint32_t mr0;
+	uint32_t mr1;
+	uint32_t mr2;
+	uint32_t mr3;
+	uint32_t tpr0;
+	uint32_t tpr1;
+	uint32_t tpr2;
+	uint32_t tpr3;
+	uint32_t tpr4;
+	uint32_t tpr5;
+	uint32_t tpr6;
+	uint32_t tpr7;
+	uint32_t tpr8;
+	uint32_t tpr9;
+	uint32_t tpr10;
+	uint32_t tpr11;
+	uint32_t tpr12;
+	uint32_t tpr13;
+	uint32_t bits;
+};
+
+static int
+dram_param_a31_validate(FILE *stream, void *raw)
+{
+	struct dram_param_a31 *param = raw;
+	char *message = "Invalid structure for " DRAM_PARAM_A31_MATCHES;
+
+	/* MHz */
+	if ((param->clk < 100) || (param->clk > 1000)) {
+		fprintf(stream, "%s: wrong clk: 0x%08X\n", message,
+		       param->clk);
+		return -1;
+	}
+
+	/* 2: DDR2, 3: DDR3, 6: LPDDR2, 7: LPDDR3 */
+	if ((param->type != 2) && (param->type != 3) &&
+	    (param->type != 6) && (param->type != 7)) {
+		fprintf(stream, "%s: wrong type: 0x%08X\n", message,
+		       param->type);
+		return -1;
+	}
+
+	if ((param->odt_en != 0) && (param->odt_en != 1)) {
+		fprintf(stream, "%s: wrong odt_en: 0x%08X\n", message,
+		       param->odt_en);
+		return -1;
+	}
+
+	fprintf(stream, "Parameters seem valid for %s.\n",
+		DRAM_PARAM_A31_MATCHES);
+	return 0;
+}
+
+static void
+dram_param_a31_print(FILE *stream, void *raw)
+{
+	struct dram_param_a31 *param = raw;
+
+	fprintf(stream, "\n; For %s\n", DRAM_PARAM_A31_MATCHES);
+	fprintf(stream, "[dram para]\n\n");
+	fprintf(stream, "dram_clk\t= %d\n", param->clk);
+	fprintf(stream, "dram_type\t= %d\n", param->type);
+	fprintf(stream, "dram_zq\t\t= 0x%x\n", param->zq);
+	fprintf(stream, "dram_odt_en\t= %d\n", param->odt_en);
+	fprintf(stream, "dram_para1\t= 0x%x\n", param->para1);
+	fprintf(stream, "dram_para2\t= 0x%x\n", param->para2);
+	fprintf(stream, "dram_mr0\t= 0x%x\n", param->mr0);
+	fprintf(stream, "dram_mr1\t= 0x%x\n", param->mr1);
+	fprintf(stream, "dram_mr2\t= 0x%x\n", param->mr2);
+	fprintf(stream, "dram_mr3\t= 0x%x\n", param->mr3);
+	fprintf(stream, "dram_tpr0\t= 0x%08x\n", param->tpr0);
+	fprintf(stream, "dram_tpr1\t= 0x%08x\n", param->tpr1);
+	fprintf(stream, "dram_tpr2\t= 0x%08x\n", param->tpr2);
+	fprintf(stream, "dram_tpr3\t= 0x%08x\n", param->tpr3);
+	fprintf(stream, "dram_tpr4\t= 0x%x\n", param->tpr4);
+	fprintf(stream, "dram_tpr5\t= 0x%x\n", param->tpr5);
+	fprintf(stream, "dram_tpr6\t= 0x%x\n", param->tpr6);
+	fprintf(stream, "dram_tpr7\t= 0x%x\n", param->tpr7);
+	fprintf(stream, "dram_tpr8\t= 0x%x\n", param->tpr8);
+	fprintf(stream, "dram_tpr9\t= 0x%x\n", param->tpr9);
+	fprintf(stream, "dram_tpr10\t= 0x%x\n", param->tpr10);
+	fprintf(stream, "dram_tpr11\t= 0x%08x\n", param->tpr11);
+	fprintf(stream, "dram_tpr12\t= 0x%08x\n", param->tpr12);
+	fprintf(stream, "dram_tpr13\t= 0x%08x\n", param->tpr13);
+	fprintf(stream, "\n");
+}
+
 static void
 dram_param_raw_print(FILE *stream, void *raw)
 {
@@ -307,6 +406,8 @@ int output_boot0_info(void *sector, FILE *inf, FILE *stream, bool verbose)
 			"\nLooking for a valid dram parameter structure...\n");
 		if (!dram_param_a10_validate(stream, dram_param))
 			dram_param_a10_print(stream, dram_param);
+		else if (!dram_param_a31_validate(stream, dram_param))
+			dram_param_a31_print(stream, dram_param);
 		else
 			dram_param_raw_print(stream, dram_param);
 	} else {

--- a/sunxi-boot0.c
+++ b/sunxi-boot0.c
@@ -159,25 +159,25 @@ dram_param_raw_print(FILE *stream, void *raw)
 int output_boot0_info(void *sector, FILE *inf, FILE *stream, bool verbose)
 {
 	struct egon_header *header = sector;
-	struct egon_header_secondary *secondary;
-	void *dram_param;
 	size_t ret;
 
-	if (!verbose) {
-		pseek(inf, header->filesize - SECTOR_SIZE);
-		return (header->filesize / SECTOR_SIZE) - 1;
+	if (verbose) {
+		struct egon_header_secondary *secondary =
+			(void *) header + header->header_size;
+		void *dram_param = secondary->dram_param;
+
+		fprintf(stream, "\tsize: %d bytes\n", header->filesize);
+
+		ret = egon_checksum_verify(stream, header, sector, inf);
+		if (ret)
+			return 0;
+
+		dram_param_raw_print(stream, dram_param);
+	} else {
+		ret = pseek(inf, header->filesize - SECTOR_SIZE);
+		if (ret)
+			return 0;
 	}
-
-	fprintf(stream, "\tsize: %d bytes\n", header->filesize);
-
-	ret = egon_checksum_verify(stream, header, sector, inf);
-	if (ret)
-		return 0;
-
-	secondary = (void *) header + header->header_size;
-	dram_param = secondary->dram_param;
-
-	dram_param_raw_print(stream, dram_param);
 
 	return (header->filesize / SECTOR_SIZE) - 1;
 }

--- a/sunxi-boot0.c
+++ b/sunxi-boot0.c
@@ -455,6 +455,132 @@ dram_param_h6_print(FILE *stream, void *raw)
 	fprintf(stream, "\n");
 }
 
+/*
+ * Should work for H616/A523/H700
+ * On H616/H700, tpr14 should be zero.
+ */
+#define DRAM_PARAM_H616_MATCHES "H616/H700/A523"
+
+struct dram_param_h616 {
+	uint32_t clk;
+	uint32_t type;
+	uint32_t dx_odt;
+	uint32_t dx_dri;
+	uint32_t ca_dri;
+	uint32_t para0;
+	uint32_t para1;
+	uint32_t para2;
+	uint32_t mr0;
+	uint32_t mr1;
+	uint32_t mr2;
+	uint32_t mr3;
+	uint32_t mr4;
+	uint32_t mr5;
+	uint32_t mr6;
+	uint32_t mr11;
+	uint32_t mr12;
+	uint32_t mr13;
+	uint32_t mr14;
+	uint32_t mr16;
+	uint32_t mr17;
+	uint32_t mr22;
+	uint32_t tpr0;
+	uint32_t tpr1;
+	uint32_t tpr2;
+	uint32_t tpr3;
+	uint32_t tpr6;
+	uint32_t tpr10;
+	uint32_t tpr11;
+	uint32_t tpr12;
+	uint32_t tpr13;
+	uint32_t tpr14;
+};
+
+static int
+dram_param_h616_validate(FILE *stream, void *raw)
+{
+	struct dram_param_h616 *param = raw;
+	char *message = "Invalid structure for " DRAM_PARAM_H616_MATCHES;
+
+	/* MHz */
+	if ((param->clk < 100) || (param->clk > 1200)) {
+		fprintf(stream, "%s: wrong clk: 0x%08X\n", message,
+		       param->clk);
+		return -1;
+	}
+
+	/* 2: DDR2, 3: DDR3, 4: DDR4,
+	   6: LPDDR2, 7: LPDDR3, 8: LPDDR4 */
+	if ((param->type != 2) && (param->type != 3) &&
+	    (param->type != 4) && (param->type != 6) &&
+	    (param->type != 7) && (param->type != 8)) {
+		fprintf(stream, "%s: wrong type: 0x%08X\n", message,
+		       param->type);
+		return -1;
+	}
+
+	if (param->dx_odt & 0xF0F0F0F0) {
+		fprintf(stream, "%s: wrong dx_odt: 0x%08X\n", message,
+		       param->dx_odt);
+		return -1;
+	}
+
+	if (param->dx_dri & 0xF0F0F0F0) {
+		fprintf(stream, "%s: wrong dx_dri: 0x%08X\n", message,
+		       param->dx_dri);
+		return -1;
+	}
+
+	fprintf(stream, "Parameters seem valid for %s.\n",
+		DRAM_PARAM_H616_MATCHES);
+	return 0;
+}
+
+static void
+dram_param_h616_print(FILE *stream, void *raw)
+{
+	struct dram_param_h616 *param = raw;
+
+	fprintf(stream, "\n; For %s\n", DRAM_PARAM_H616_MATCHES);
+	fprintf(stream, "[dram para]\n\n");
+
+	fprintf(stream, "dram_clk\t   = %d,\n", param->clk);
+	fprintf(stream, "dram_type\t   = %d,\n", param->type);
+	fprintf(stream, "dram_dx_odt\t   = 0x%08X,\n", param->dx_odt);
+	fprintf(stream, "dram_dx_dri\t   = 0x%08X,\n", param->dx_dri);
+	fprintf(stream, "dram_ca_dri\t   = 0x%08X,\n", param->ca_dri);
+	fprintf(stream, "dram_para0\t   = 0x%08X, ; aka odt_en on H616/H700\n",
+		param->para0);
+	fprintf(stream, "dram_para1\t   = 0x%08X,\n", param->para1);
+	fprintf(stream, "dram_para2\t   = 0x%08X,\n", param->para2);
+	fprintf(stream, "dram_mr0\t   = 0x%X,\n", param->mr0);
+	fprintf(stream, "dram_mr1\t   = 0x%X,\n", param->mr1);
+	fprintf(stream, "dram_mr2\t   = 0x%X,\n", param->mr2);
+	fprintf(stream, "dram_mr3\t   = 0x%X,\n", param->mr3);
+	fprintf(stream, "dram_mr4\t   = 0x%X,\n", param->mr4);
+	fprintf(stream, "dram_mr5\t   = 0x%X,\n", param->mr5);
+	fprintf(stream, "dram_mr6\t   = 0x%X,\n", param->mr6);
+	fprintf(stream, "dram_mr11\t   = 0x%X,\n", param->mr11);
+	fprintf(stream, "dram_mr12\t   = 0x%X,\n", param->mr12);
+	fprintf(stream, "dram_mr13\t   = 0x%X,\n", param->mr13);
+	fprintf(stream, "dram_mr14\t   = 0x%X,\n", param->mr14);
+	fprintf(stream, "dram_mr16\t   = 0x%X,\n", param->mr16);
+	fprintf(stream, "dram_mr17\t   = 0x%X,\n", param->mr17);
+	fprintf(stream, "dram_mr22\t   = 0x%X,\n", param->mr22);
+	fprintf(stream, "dram_tpr0\t   = 0x%08X,\n", param->tpr0);
+	fprintf(stream, "dram_tpr1\t   = 0x%X,\n", param->tpr1);
+	fprintf(stream, "dram_tpr2\t   = 0x%X,\n", param->tpr2);
+	fprintf(stream, "dram_tpr3\t   = 0x%X,\n", param->tpr3);
+	fprintf(stream, "dram_tpr6\t   = 0x%08X,\n", param->tpr6);
+	fprintf(stream, "dram_tpr10\t   = 0x%08X,\n", param->tpr10);
+	fprintf(stream, "dram_tpr11\t   = 0x%08X,\n", param->tpr11);
+	fprintf(stream, "dram_tpr12\t   = 0x%08X,\n", param->tpr12);
+	fprintf(stream, "dram_tpr13\t   = 0x%X,\n", param->tpr13);
+	fprintf(stream, "dram_tpr14\t   = 0x%X, ; "
+		"unused and 0 on anything but A523\n", param->tpr14);
+	fprintf(stream, "\n");
+}
+
 static void
 dram_param_raw_print(FILE *stream, void *raw)
 {
@@ -525,6 +651,8 @@ int output_boot0_info(void *sector, FILE *inf, FILE *stream, bool verbose)
 			dram_param_h6_print(stream, dram_param);
 		else if (!dram_param_a31_validate(stream, dram_param))
 			dram_param_a31_print(stream, dram_param);
+		else if (!dram_param_h616_validate(stream, dram_param))
+			dram_param_h616_print(stream, dram_param);
 		else
 			dram_param_raw_print(stream, dram_param);
 	} else {

--- a/sunxi-boot0.c
+++ b/sunxi-boot0.c
@@ -16,6 +16,8 @@
 
 #define __maybe_unused  __attribute__((unused))
 
+#define SECTOR_SIZE 512
+
 struct egon_header {
 	uint32_t jump;
 #define EGON_MAGIC_0 "eGON.BT0"
@@ -118,8 +120,8 @@ int output_boot0_info(void *sector, FILE *inf, FILE *stream, bool verbose)
 	size_t ret;
 
 	if (!verbose) {
-		pseek(inf, header->filesize - 512);
-		return (header->filesize / 512) - 1;
+		pseek(inf, header->filesize - SECTOR_SIZE);
+		return (header->filesize / SECTOR_SIZE) - 1;
 	}
 
 	fprintf(stream, "\tsize: %d bytes\n", header->filesize);
@@ -127,14 +129,15 @@ int output_boot0_info(void *sector, FILE *inf, FILE *stream, bool verbose)
 	buffer = malloc(header->filesize);
 	if (!buffer)
 		return 0;
-	ret = fread(buffer + (512 / 4), 1, header->filesize - 512, inf);
-	if (ret < header->filesize - 512) {
+	ret = fread(buffer + (SECTOR_SIZE / 4), 1,
+		    header->filesize - SECTOR_SIZE, inf);
+	if (ret < header->filesize - SECTOR_SIZE) {
 		fprintf(stream, "\tERROR: image file too small\n");
 		free(buffer);
 
-		return ret / 512;
+		return ret / SECTOR_SIZE;
 	}
-	memcpy(buffer, sector, 512);
+	memcpy(buffer, sector, SECTOR_SIZE);
 
 	for (i = 0; i < header->filesize / 4; i++)
 		if (i != 3)
@@ -151,5 +154,5 @@ int output_boot0_info(void *sector, FILE *inf, FILE *stream, bool verbose)
 
 	dram_param_raw_print(stream, dram_param);
 
-	return ret / 512;
+	return ret / SECTOR_SIZE;
 }

--- a/sunxi-boot0.c
+++ b/sunxi-boot0.c
@@ -18,154 +18,25 @@
 #define BOOT0_CHECKSUM	3
 #define BOOT0_LENGTH	4
 #define BOOT0_DRAM_OFS	14
-#define OFS(x) ((x) + BOOT0_DRAM_OFS)
 
-enum dram_para {
-	DRAM_PARAM_NOT_USED = 0,
-	DRAM_CLK,
-	DRAM_TYPE,
-	DRAM_ZQ,
-	DRAM_ODT_EN,
-	DRAM_DX_ODT,
-	DRAM_DX_DRI,
-	DRAM_CA_DRI,
-	DRAM_PARA1, DRAM_PARA2,
-	DRAM_MR0, DRAM_MR1, DRAM_MR2, DRAM_MR3,
-	DRAM_MR4, DRAM_MR5, DRAM_MR6, DRAM_MR7,
-	DRAM_MR8, DRAM_MR9, DRAM_MR10, DRAM_MR11,
-	DRAM_MR12, DRAM_MR13, DRAM_MR14, DRAM_MR15,
-	DRAM_MR16, DRAM_MR17, DRAM_MR18, DRAM_MR19,
-	DRAM_MR20, DRAM_MR21, DRAM_MR22,
-	DRAM_TPR0, DRAM_TPR1, DRAM_TPR2, DRAM_TPR3,
-	DRAM_TPR4, DRAM_TPR5, DRAM_TPR6, DRAM_TPR7,
-	DRAM_TPR8, DRAM_TPR9, DRAM_TPR10, DRAM_TPR11,
-	DRAM_TPR12, DRAM_TPR13,
-	NR_DRAM_PARAMS
-};
+#define EGON_DRAM_PARAM_COUNT 32
 
-static const char *param_name[] = {
-	[DRAM_PARAM_NOT_USED] = "unused",
-	[DRAM_CLK] = "DRAM clock",
-	[DRAM_TYPE] = "DRAM type",
-	[DRAM_ZQ] = "ZQ value",
-	[DRAM_ODT_EN] = "ODT enabled",
-	[DRAM_DX_ODT] = "DX ODT",
-	[DRAM_DX_DRI] = "DX DRI",
-	[DRAM_CA_DRI] = "CA DRI",
-	[DRAM_PARA1] = "PARA1",
-	[DRAM_PARA2] = "PARA2",
-	[DRAM_MR0] = "MR0",
-	[DRAM_MR1] = "MR1",
-	[DRAM_MR2] = "MR2",
-	[DRAM_MR3] = "MR3",
-	[DRAM_MR4] = "MR4",
-	[DRAM_MR5] = "MR5",
-	[DRAM_MR6] = "MR6",
-	[DRAM_MR7] = "MR7",
-	[DRAM_MR8] = "MR8",
-	[DRAM_MR9] = "MR9",
-	[DRAM_MR10] = "MR10",
-	[DRAM_MR11] = "MR11",
-	[DRAM_MR12] = "MR12",
-	[DRAM_MR13] = "MR13",
-	[DRAM_MR14] = "MR14",
-	[DRAM_MR15] = "MR15",
-	[DRAM_MR16] = "MR16",
-	[DRAM_MR17] = "MR17",
-	[DRAM_MR18] = "MR18",
-	[DRAM_MR19] = "MR19",
-	[DRAM_MR20] = "MR20",
-	[DRAM_MR21] = "MR21",
-	[DRAM_MR22] = "MR22",
-	[DRAM_TPR0] = "TPR0",
-	[DRAM_TPR1] = "TPR1",
-	[DRAM_TPR2] = "TPR2",
-	[DRAM_TPR3] = "TPR3",
-	[DRAM_TPR4] = "TPR4",
-	[DRAM_TPR5] = "TPR5",
-	[DRAM_TPR6] = "TPR6",
-	[DRAM_TPR7] = "TPR7",
-	[DRAM_TPR8] = "TPR8",
-	[DRAM_TPR9] = "TPR9",
-	[DRAM_TPR10] = "TRP10",
-	[DRAM_TPR11] = "TRP11",
-	[DRAM_TPR12] = "TRP12",
-	[DRAM_TPR13] = "TRP13",
-};
+static void
+dram_param_raw_print(FILE *stream, void *raw)
+{
+	uint32_t *param = raw;
+	int i;
 
-enum soc_types {
-	SOC_A64 = 0,
-	SOC_H616,
-	SOC_H6,
-	NR_SOC_TYPES
-};
-
-static int8_t register_mappings[NR_SOC_TYPES][NR_DRAM_PARAMS] = {
-	[SOC_A64] = {
-		[DRAM_CLK] = OFS(0),
-		[DRAM_TYPE] = OFS(1),
-		[DRAM_ZQ] = OFS(2),
-		[DRAM_ODT_EN] = OFS(3),
-		[DRAM_PARA1] = OFS(4),
-		[DRAM_PARA2] = OFS(5),
-		[DRAM_MR0] = OFS(6),
-		[DRAM_MR1] = OFS(7),
-		[DRAM_MR2] = OFS(8),
-		[DRAM_MR3] = OFS(9),
-		[DRAM_TPR0] = OFS(10),
-		[DRAM_TPR1] = OFS(11),
-		[DRAM_TPR2] = OFS(12),
-		[DRAM_TPR3] = OFS(13),
-		[DRAM_TPR4] = OFS(14),
-		[DRAM_TPR5] = OFS(15),
-		[DRAM_TPR6] = OFS(16),
-		[DRAM_TPR7] = OFS(17),
-		[DRAM_TPR8] = OFS(18),
-		[DRAM_TPR9] = OFS(19),
-		[DRAM_TPR10] = OFS(20),
-		[DRAM_TPR11] = OFS(21),
-		[DRAM_TPR12] = OFS(22),
-		[DRAM_TPR13] = OFS(23),
-	},
-	[SOC_H616] = {
-		[DRAM_CLK] = OFS(0),
-		[DRAM_TYPE] = OFS(1),
-		[DRAM_DX_ODT] = OFS(2),
-		[DRAM_DX_DRI] = OFS(3),
-		[DRAM_CA_DRI] = OFS(4),
-		[DRAM_ODT_EN] = OFS(5),
-		[DRAM_PARA1] = OFS(6),
-		[DRAM_PARA2] = OFS(7),
-		[DRAM_MR0] = OFS(8),
-		[DRAM_MR1] = OFS(9),
-		[DRAM_MR2] = OFS(10),
-		[DRAM_MR3] = OFS(11),
-		[DRAM_MR4] = OFS(12),
-		[DRAM_MR5] = OFS(13),
-		[DRAM_MR6] = OFS(14),
-		[DRAM_MR11] = OFS(15),
-		[DRAM_MR12] = OFS(16),
-		[DRAM_MR13] = OFS(17),
-		[DRAM_MR14] = OFS(18),
-		[DRAM_MR16] = OFS(19),
-		[DRAM_MR17] = OFS(20),
-		[DRAM_MR22] = OFS(21),
-		[DRAM_TPR0] = OFS(22),
-		[DRAM_TPR1] = OFS(23),
-		[DRAM_TPR2] = OFS(24),
-		[DRAM_TPR3] = OFS(25),
-		[DRAM_TPR6] = OFS(26),
-		[DRAM_TPR10] = OFS(27),
-		[DRAM_TPR11] = OFS(28),
-		[DRAM_TPR12] = OFS(29),
-		[DRAM_TPR13] = OFS(30),
-	},
-};
+	fprintf(stream, "; Unknown structure\n");
+	for (i = 0; i < EGON_DRAM_PARAM_COUNT; i++)
+		fprintf(stream, "dram_%02d\t= 0x%08X\n", i, param[i]);
+}
 
 int output_boot0_info(void *sector, FILE *inf, FILE *stream, bool verbose)
 {
 	const uint32_t *boot0 = sector;
 	uint32_t *buffer, i, chksum = CHECKSUM_SEED;
+	void *dram_param;
 	size_t ret;
 
 	if (!verbose) {
@@ -197,31 +68,9 @@ int output_boot0_info(void *sector, FILE *inf, FILE *stream, bool verbose)
 			chksum, boot0[BOOT0_CHECKSUM]);
 	free(buffer);
 
-	fprintf(stream, "\tDRAM parameters:\tA64\t\tH616\n");
+	dram_param = (void *) &boot0[BOOT0_DRAM_OFS];
 
-	for (i = 0; i < NR_DRAM_PARAMS; i++) {
-		int ver;
-
-		for (ver = 0; ver < NR_SOC_TYPES; ver++)
-			if (register_mappings[ver][i] &&
-			    boot0[register_mappings[ver][i]])
-				break;
-		/* if this parameter is unused, skip the output */
-		if (ver == NR_SOC_TYPES)
-			continue;
-
-
-		fprintf(stream, "\t\t%-12s:", param_name[i]);
-
-		for (ver = 0; ver < NR_SOC_TYPES; ver++) {
-			if (register_mappings[ver][i] == 0)
-				fprintf(stream, "           -");
-			else
-				fprintf(stream, "  %#10x",
-					boot0[register_mappings[ver][i]]);
-		}
-		fprintf(stream, "\n");
-	}
+	dram_param_raw_print(stream, dram_param);
 
 	return ret / 512;
 }

--- a/sunxi-boot0.c
+++ b/sunxi-boot0.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 /*
  * (C) Copyright 2020, Andre Przywara
+ * Copyright (c) 2024 Luc Verhaegen <libv@skynet.be>
  *
  * sunxi-boot0: dump basic information about an Allwinner eGON image
  */
@@ -13,13 +14,89 @@
 
 #include "sunxi-fw.h"
 
-#define CHECKSUM_SEED	0x5f0a6c39
+#define __maybe_unused  __attribute__((unused))
 
-#define BOOT0_CHECKSUM	3
-#define BOOT0_LENGTH	4
-#define BOOT0_DRAM_OFS	14
+struct egon_header {
+	uint32_t jump;
+#define EGON_MAGIC_0 "eGON.BT0"
+#define EGON_MAGIC_1 "eGON.BT1"
+	char magic[8];
+#define EGON_CHECKSUM_SEED 0x5f0a6c39
+	uint32_t checksum;
+#define EGON_FILESIZE_ALIGN 4096
+	uint32_t filesize;
+	uint32_t header_size;
+	char header_version[4];
+	uint32_t return_address;
+	uint32_t run_address;
+	char eGON_version[4];
+	char platform_info[8];
+};
 
+static void __maybe_unused
+egon_header_print(FILE *stream, struct egon_header *header)
+{
+	fprintf(stream, "struct egon_header header[1] = {\n");
+
+	fprintf(stream, "\t.jump = 0x%08X,\n", header->jump);
+	fprintf(stream, "\t.magic = \"%c%c%c%c%c%c%c%c\",\n",
+		header->magic[0], header->magic[1],
+		header->magic[2], header->magic[3],
+		header->magic[4], header->magic[5],
+		header->magic[6], header->magic[7]);
+	fprintf(stream, "\t.checksum = 0x%08X,\n", header->checksum);
+	fprintf(stream, "\t.filesize = 0x%08X, /* %dbytes */\n",
+		header->filesize, header->filesize);
+	fprintf(stream, "\t.header_size = 0x%08X,\n", header->header_size);
+	fprintf(stream, "\t.header_version = \"%c%c%c%c\",\n",
+		header->header_version[0], header->header_version[1],
+		header->header_version[2], header->header_version[3]);
+	fprintf(stream, "\t.return_address = 0x%08X,\n",
+		header->return_address);
+	fprintf(stream, "\t.run_address = 0x%08X,\n", header->run_address);
+	fprintf(stream, "\t.eGON_version = \"%c%c%c%c\",\n",
+		header->eGON_version[0], header->eGON_version[1],
+		header->eGON_version[2], header->eGON_version[3]);
+	fprintf(stream, "\t.platform_info = \"%c%c%c%c%c%c%c%c\",\n",
+		header->platform_info[0], header->platform_info[1],
+		header->platform_info[2], header->platform_info[3],
+		header->platform_info[4], header->platform_info[5],
+		header->platform_info[6], header->platform_info[7]);
+
+	fprintf(stream, "};\n\n");
+}
+
+struct egon_header_secondary {
+	uint32_t header_size;
+	char header_version[4];
 #define EGON_DRAM_PARAM_COUNT 32
+	uint32_t dram_param[EGON_DRAM_PARAM_COUNT];
+	/* ignore the rest of this struct for now. */
+};
+
+static void __maybe_unused
+egon_header_secondary_print(FILE *stream,
+			    struct egon_header_secondary *header)
+{
+	int i;
+
+	fprintf(stream, "struct egon_header header[1] = {\n");
+
+	fprintf(stream, "\t.header_size = 0x%08X,\n", header->header_size);
+	fprintf(stream, "\t.header_version = \"%c%c%c%c\",\n",
+	       header->header_version[0],
+	       header->header_version[1],
+	       header->header_version[2],
+	       header->header_version[3]);
+
+	for (i = 0; i < EGON_DRAM_PARAM_COUNT; i++)
+		fprintf(stream, "\t.dram_param[0x%02X] = 0x%08X,\n",
+		       i, header->dram_param[i]);
+
+	fprintf(stream, "\t/* ... */\n");
+
+	fprintf(stream, "};\n\n");
+}
 
 static void
 dram_param_raw_print(FILE *stream, void *raw)
@@ -34,23 +111,24 @@ dram_param_raw_print(FILE *stream, void *raw)
 
 int output_boot0_info(void *sector, FILE *inf, FILE *stream, bool verbose)
 {
-	const uint32_t *boot0 = sector;
-	uint32_t *buffer, i, chksum = CHECKSUM_SEED;
+	struct egon_header *header = sector;
+	struct egon_header_secondary *secondary;
+	uint32_t *buffer, i, chksum = EGON_CHECKSUM_SEED;
 	void *dram_param;
 	size_t ret;
 
 	if (!verbose) {
-		pseek(inf, boot0[BOOT0_LENGTH] - 512);
-		return (boot0[BOOT0_LENGTH] / 512) - 1;
+		pseek(inf, header->filesize - 512);
+		return (header->filesize / 512) - 1;
 	}
 
-	fprintf(stream, "\tsize: %d bytes\n", boot0[BOOT0_LENGTH]);
+	fprintf(stream, "\tsize: %d bytes\n", header->filesize);
 
-	buffer = malloc(boot0[BOOT0_LENGTH]);
+	buffer = malloc(header->filesize);
 	if (!buffer)
 		return 0;
-	ret = fread(buffer + (512 / 4), 1, boot0[BOOT0_LENGTH] - 512, inf);
-	if (ret < boot0[BOOT0_LENGTH] - 512) {
+	ret = fread(buffer + (512 / 4), 1, header->filesize - 512, inf);
+	if (ret < header->filesize - 512) {
 		fprintf(stream, "\tERROR: image file too small\n");
 		free(buffer);
 
@@ -58,17 +136,18 @@ int output_boot0_info(void *sector, FILE *inf, FILE *stream, bool verbose)
 	}
 	memcpy(buffer, sector, 512);
 
-	for (i = 0; i < boot0[BOOT0_LENGTH] / 4; i++)
+	for (i = 0; i < header->filesize / 4; i++)
 		if (i != 3)
 			chksum += buffer[i];
-	if (chksum == boot0[BOOT0_CHECKSUM])
+	if (chksum == header->checksum)
 		fprintf(stream, "\teGON checksum matches: 0x%08x\n", chksum);
 	else
 		fprintf(stream, "\teGON checksum: 0x%08x, programmed: 0x%08x\n",
-			chksum, boot0[BOOT0_CHECKSUM]);
+			chksum, header->checksum);
 	free(buffer);
 
-	dram_param = (void *) &boot0[BOOT0_DRAM_OFS];
+	secondary = (void *) header + header->header_size;
+	dram_param = secondary->dram_param;
 
 	dram_param_raw_print(stream, dram_param);
 

--- a/sunxi-boot0.c
+++ b/sunxi-boot0.c
@@ -340,6 +340,121 @@ dram_param_a31_print(FILE *stream, void *raw)
 	fprintf(stream, "\n");
 }
 
+/*
+ * should work for H6
+ */
+#define DRAM_PARAM_H6_MATCHES "H6"
+
+struct dram_param_h6 {
+	uint32_t clk;
+	uint32_t type;
+	uint32_t zq;
+	uint32_t odt_en;
+	uint32_t para1;
+	uint32_t para2;
+	uint32_t mr0;
+	uint32_t mr1;
+	uint32_t mr2;
+	uint32_t mr3;
+	uint32_t mr4;
+	uint32_t mr5;
+	uint32_t mr6;
+	uint32_t tpr0;
+	uint32_t tpr1;
+	uint32_t tpr2;
+	uint32_t tpr3;
+	uint32_t tpr4;
+	uint32_t tpr5;
+	uint32_t tpr6;
+	uint32_t tpr7;
+	uint32_t tpr8;
+	uint32_t tpr9;
+	uint32_t tpr10;
+	uint32_t tpr11;
+	uint32_t tpr12;
+	uint32_t tpr13;
+	uint32_t bits;
+};
+
+/*
+ * Call this before a31_validate, so .bits can trigger invalidation.
+ */
+static int
+dram_param_h6_validate(FILE *stream, void *raw)
+{
+	struct dram_param_h6 *param = raw;
+	char *message = "Invalid structure for " DRAM_PARAM_H6_MATCHES;
+
+	/* MHz */
+	if ((param->clk < 100) || (param->clk > 1000)) {
+		fprintf(stream, "%s: wrong clk: 0x%08X\n", message,
+		       param->clk);
+		return -1;
+	}
+
+	/* 2: DDR2, 3: DDR3, 6: LPDDR2, 7: LPDDR3 */
+	if ((param->type != 2) && (param->type != 3) &&
+	    (param->type != 6) && (param->type != 7)) {
+		fprintf(stream, "%s: wrong type: 0x%08X\n", message,
+		       param->type);
+		return -1;
+	}
+
+	if ((param->odt_en != 0) && (param->odt_en != 1)) {
+		fprintf(stream, "%s: wrong odt_en: 0x%08X\n", message,
+		       param->odt_en);
+		return -1;
+	}
+
+	if ((param->bits != 16) && (param->bits != 32)) {
+		fprintf(stream, "%s: wrong bits: 0x%08X\n", message,
+		       param->bits);
+		return -1;
+	}
+
+	fprintf(stream, "Parameters seem valid for %s.\n",
+		DRAM_PARAM_H6_MATCHES);
+	return 0;
+}
+
+static void
+dram_param_h6_print(FILE *stream, void *raw)
+{
+	struct dram_param_h6 *param = raw;
+
+	fprintf(stream, "\n; For %s\n", DRAM_PARAM_H6_MATCHES);
+	fprintf(stream, "[dram para]\n\n");
+	fprintf(stream, "dram_clk\t= %d\n", param->clk);
+	fprintf(stream, "dram_type\t= %d\n", param->type);
+	fprintf(stream, "dram_zq\t\t= 0x%x\n", param->zq);
+	fprintf(stream, "dram_odt_en\t= %d\n", param->odt_en);
+	fprintf(stream, "dram_para1\t= 0x%x\n", param->para1);
+	fprintf(stream, "dram_para2\t= 0x%x\n", param->para2);
+	fprintf(stream, "dram_mr0\t= 0x%x\n", param->mr0);
+	fprintf(stream, "dram_mr1\t= 0x%x\n", param->mr1);
+	fprintf(stream, "dram_mr2\t= 0x%x\n", param->mr2);
+	fprintf(stream, "dram_mr3\t= 0x%x\n", param->mr3);
+	fprintf(stream, "dram_mr4\t= 0x%x\n", param->mr4);
+	fprintf(stream, "dram_mr5\t= 0x%x\n", param->mr5);
+	fprintf(stream, "dram_mr6\t= 0x%x\n", param->mr6);
+	fprintf(stream, "dram_tpr0\t= 0x%08x\n", param->tpr0);
+	fprintf(stream, "dram_tpr1\t= 0x%08x\n", param->tpr1);
+	fprintf(stream, "dram_tpr2\t= 0x%08x\n", param->tpr2);
+	fprintf(stream, "dram_tpr3\t= 0x%08x\n", param->tpr3);
+	fprintf(stream, "dram_tpr4\t= 0x%x\n", param->tpr4);
+	fprintf(stream, "dram_tpr5\t= 0x%x\n", param->tpr5);
+	fprintf(stream, "dram_tpr6\t= 0x%x\n", param->tpr6);
+	fprintf(stream, "dram_tpr7\t= 0x%x\n", param->tpr7);
+	fprintf(stream, "dram_tpr8\t= 0x%x\n", param->tpr8);
+	fprintf(stream, "dram_tpr9\t= 0x%x\n", param->tpr9);
+	fprintf(stream, "dram_tpr10\t= 0x%x\n", param->tpr10);
+	fprintf(stream, "dram_tpr11\t= 0x%08x\n", param->tpr11);
+	fprintf(stream, "dram_tpr12\t= 0x%08x\n", param->tpr12);
+	fprintf(stream, "dram_tpr13\t= 0x%08x\n", param->tpr13);
+	fprintf(stream, "dram_bits\t= %d\n", param->bits);
+	fprintf(stream, "\n");
+}
+
 static void
 dram_param_raw_print(FILE *stream, void *raw)
 {
@@ -406,6 +521,8 @@ int output_boot0_info(void *sector, FILE *inf, FILE *stream, bool verbose)
 			"\nLooking for a valid dram parameter structure...\n");
 		if (!dram_param_a10_validate(stream, dram_param))
 			dram_param_a10_print(stream, dram_param);
+		else if (!dram_param_h6_validate(stream, dram_param))
+			dram_param_h6_print(stream, dram_param);
 		else if (!dram_param_a31_validate(stream, dram_param))
 			dram_param_a31_print(stream, dram_param);
 		else


### PR DESCRIPTION
This reworks everything to be struct based instead of an index in a uint32_t table.

eGON header handling has been reworked.

A valiant attempt was made to add some sensible heuristics to parse dram_para, to enable printing which matches the fex file.

Tested on images for:
a20: Giada ni-a20
a23: q88pro
a31: msi primo 81
a33: astar a33
a523: teclast p26t
a64: bpi m64
a80: generic a80 tv box called cs-q8
a83t: bpi-m3
h3: generic h3 tv box labelled "atv10"
h6: generic h6 tv box
h616: h96max
h616: opi zero3
h700: anbernic 35xxp