### PR TITLE
boot0: Add A133 DRAM parameter support and DRAM.ext support

### DIFF
--- a/sunxi-boot0.c
+++ b/sunxi-boot0.c
@@ -20,6 +20,13 @@
 #define BOOT0_DRAM_OFS	14
 #define OFS(x) ((x) + 1)
 
+#define DRAM_EXT_MAGIC_OFS	210
+#define DRAM_EXT_MAGIC1		0x4d415244	// "DRAM"
+#define DRAM_EXT_MAGIC2		0x7478652e	// ".ext"
+#define DRAM_EXT_PARA_OFS	221
+#define DRAM_EXT_PARA_SIZE	32
+#define DRAM_EXT_PARA_CNT	15
+
 enum dram_para {
 	DRAM_PARAM_NOT_USED = 0,
 	DRAM_CLK,
@@ -239,6 +246,19 @@ void output_boot0_dram_para(const uint32_t *para, FILE *stream, char const* inde
 	}
 }
 
+void output_dram_ext_info(const uint32_t *buffer, FILE *stream)
+{
+	uint32_t i, ofs;
+	ofs = DRAM_EXT_PARA_OFS;
+	for (i = 0; i < DRAM_EXT_PARA_CNT; i++) {
+		if (buffer[ofs] != 0) {
+			fprintf(stream, "\tDRAM parameters %X:   ", i + 1);
+			output_boot0_dram_para(&buffer[ofs], stream, "\t");
+		}
+		ofs += DRAM_EXT_PARA_SIZE;
+	}
+}
+
 int output_boot0_info(void *sector, FILE *inf, FILE *stream, bool verbose)
 {
 	const uint32_t *boot0 = sector;
@@ -272,10 +292,16 @@ int output_boot0_info(void *sector, FILE *inf, FILE *stream, bool verbose)
 	else
 		fprintf(stream, "\teGON checksum: 0x%08x, programmed: 0x%08x\n",
 			chksum, boot0[BOOT0_CHECKSUM]);
-	free(buffer);
 
 	fprintf(stream, "\tDRAM parameters:     ");
 	output_boot0_dram_para(&boot0[BOOT0_DRAM_OFS], stream, "\t");
 
+	if (buffer[DRAM_EXT_MAGIC_OFS] == DRAM_EXT_MAGIC1 &&
+	    buffer[DRAM_EXT_MAGIC_OFS + 1] == DRAM_EXT_MAGIC2)
+		output_dram_ext_info(buffer, stream);
+
+	free(buffer);
+
 	return ret / 512;
 }
+

--- a/sunxi-boot0.c
+++ b/sunxi-boot0.c
@@ -87,10 +87,10 @@ static const char *param_name[] = {
 	[DRAM_TPR7] = "TPR7",
 	[DRAM_TPR8] = "TPR8",
 	[DRAM_TPR9] = "TPR9",
-	[DRAM_TPR10] = "TRP10",
-	[DRAM_TPR11] = "TRP11",
-	[DRAM_TPR12] = "TRP12",
-	[DRAM_TPR13] = "TRP13",
+	[DRAM_TPR10] = "TPR10",
+	[DRAM_TPR11] = "TPR11",
+	[DRAM_TPR12] = "TPR12",
+	[DRAM_TPR13] = "TPR13",
 };
 
 enum soc_types {

--- a/sunxi-boot0.c
+++ b/sunxi-boot0.c
@@ -29,7 +29,7 @@ enum dram_para {
 	DRAM_DX_ODT,
 	DRAM_DX_DRI,
 	DRAM_CA_DRI,
-	DRAM_PARA1, DRAM_PARA2,
+	DRAM_PARA0, DRAM_PARA1, DRAM_PARA2,
 	DRAM_MR0, DRAM_MR1, DRAM_MR2, DRAM_MR3,
 	DRAM_MR4, DRAM_MR5, DRAM_MR6, DRAM_MR7,
 	DRAM_MR8, DRAM_MR9, DRAM_MR10, DRAM_MR11,
@@ -39,7 +39,7 @@ enum dram_para {
 	DRAM_TPR0, DRAM_TPR1, DRAM_TPR2, DRAM_TPR3,
 	DRAM_TPR4, DRAM_TPR5, DRAM_TPR6, DRAM_TPR7,
 	DRAM_TPR8, DRAM_TPR9, DRAM_TPR10, DRAM_TPR11,
-	DRAM_TPR12, DRAM_TPR13,
+	DRAM_TPR12, DRAM_TPR13, DRAM_TPR14,
 	NR_DRAM_PARAMS
 };
 
@@ -52,6 +52,7 @@ static const char *param_name[] = {
 	[DRAM_DX_ODT] = "DX ODT",
 	[DRAM_DX_DRI] = "DX DRI",
 	[DRAM_CA_DRI] = "CA DRI",
+	[DRAM_PARA0] = "PARA0",
 	[DRAM_PARA1] = "PARA1",
 	[DRAM_PARA2] = "PARA2",
 	[DRAM_MR0] = "MR0",
@@ -91,11 +92,13 @@ static const char *param_name[] = {
 	[DRAM_TPR11] = "TPR11",
 	[DRAM_TPR12] = "TPR12",
 	[DRAM_TPR13] = "TPR13",
+	[DRAM_TPR14] = "TPR14",
 };
 
 enum soc_types {
 	SOC_A64 = 0,
 	SOC_H616,
+	SOC_A133,
 	SOC_H6,
 	NR_SOC_TYPES
 };
@@ -160,6 +163,40 @@ static int8_t register_mappings[NR_SOC_TYPES][NR_DRAM_PARAMS] = {
 		[DRAM_TPR12] = OFS(29),
 		[DRAM_TPR13] = OFS(30),
 	},
+	[SOC_A133] = {
+		[DRAM_CLK] = OFS(0),
+		[DRAM_TYPE] = OFS(1),
+		[DRAM_DX_ODT] = OFS(2),
+		[DRAM_DX_DRI] = OFS(3),
+		[DRAM_CA_DRI] = OFS(4),
+		[DRAM_PARA0] = OFS(5),
+		[DRAM_PARA1] = OFS(6),
+		[DRAM_PARA2] = OFS(7),
+		[DRAM_MR0] = OFS(8),
+		[DRAM_MR1] = OFS(9),
+		[DRAM_MR2] = OFS(10),
+		[DRAM_MR3] = OFS(11),
+		[DRAM_MR4] = OFS(12),
+		[DRAM_MR5] = OFS(13),
+		[DRAM_MR6] = OFS(14),
+		[DRAM_MR11] = OFS(15),
+		[DRAM_MR12] = OFS(16),
+		[DRAM_MR13] = OFS(17),
+		[DRAM_MR14] = OFS(18),
+		[DRAM_MR17] = OFS(19),
+		[DRAM_TPR0] = OFS(20),
+		[DRAM_TPR1] = OFS(21),
+		[DRAM_TPR2] = OFS(22),
+		[DRAM_TPR3] = OFS(23),
+		[DRAM_TPR4] = OFS(24),
+		[DRAM_TPR5] = OFS(25),
+		[DRAM_TPR6] = OFS(26),
+		[DRAM_TPR10] = OFS(27),
+		[DRAM_TPR11] = OFS(28),
+		[DRAM_TPR12] = OFS(29),
+		[DRAM_TPR13] = OFS(30),
+		[DRAM_TPR14] = OFS(31),
+	}
 };
 
 int output_boot0_info(void *sector, FILE *inf, FILE *stream, bool verbose)
@@ -197,7 +234,7 @@ int output_boot0_info(void *sector, FILE *inf, FILE *stream, bool verbose)
 			chksum, boot0[BOOT0_CHECKSUM]);
 	free(buffer);
 
-	fprintf(stream, "\tDRAM parameters:\tA64\t\tH616\n");
+	fprintf(stream, "\tDRAM parameters:\tA64\t\tH616\t\tA133\n");
 
 	for (i = 0; i < NR_DRAM_PARAMS; i++) {
 		int ver;


### PR DESCRIPTION
This was tested using the PhoenixSuite recovery image for the Creality Sonic Pad. Adding the initial DRAM parameter support did not display the expected parameters; after further investigation I discovered the existence of the extended header. This may be present on boot0 images besides the A133, so I made it a generalized feature. These are also stored in the `sys_config.fex` in additional `[dram_para%d]` sections

Along with this is some small typo fixes in the para_names array and a refactor of the DRAM parameters prints to move it into another function, so it can be used in the DRAM.ext output code.

<details>
<summary>Output from <code>sunxi-fw info -v</code> on my device's boot0 with these changes</summary>

```
@   0: boot0: Allwinner boot0
        size: 65536 bytes
        eGON checksum matches: 0x6aaf5251
        DRAM parameters:              A64        H616        A133          H6
                DRAM clock  :       0x2d0       0x2d0       0x2d0           -
                DRAM type   :         0x3         0x3         0x3           -
                ZQ value    :   0x7070707           -           -           -
                ODT enabled :   0xc0c0c0c  0x15101212           -           -
                DX ODT      :           -   0x7070707   0x7070707           -
                DX DRI      :           -   0xc0c0c0c   0xc0c0c0c           -
                CA DRI      :           -       0xe0e       0xe0e           -
                PARA0       :           -           -  0x15101212           -
                PARA1       :       0xe0e      0x30fa      0x30fa           -
                PARA2       :  0x15101212           0           0           -
                MR0         :      0x30fa       0x840       0x840           -
                MR1         :           0         0x4         0x4           -
                MR2         :       0x840         0x8         0x8           -
                MR3         :         0x4           0           0           -
                TPR0        :         0x8           0           0           -
                TPR6        :           0  0x33808080  0x33808080           -
                TPR10       :           0    0x2f7458    0x2f7458           -
                TPR11       :           0   0xf0b0e0c   0xf0b0e0c           -
                TPR12       :           0  0x19191818  0x19191818           -
                TPR13       :           0        0x40        0x40           -
                TPR14       :           -           -  0x26232323           -
        DRAM parameters 3:            A64        H616        A133          H6
                DRAM clock  :       0x2d0       0x2d0       0x2d0           -
                DRAM type   :         0x4         0x4         0x4           -
                ZQ value    :   0x3030303           -           -           -
                ODT enabled :   0xc0c0c0c  0x12131615           -           -
                DX ODT      :           -   0x3030303   0x3030303           -
                DX DRI      :           -   0xc0c0c0c   0xc0c0c0c           -
                CA DRI      :           -      0x1919      0x1919           -
                PARA0       :           -           -  0x12131615           -
                PARA1       :      0x1919      0x60fa      0x60fa           -
                PARA2       :  0x12131615           0           0           -
                MR0         :      0x60fa       0x840       0x840           -
                MR1         :           0       0x601       0x601           -
                MR2         :       0x840         0x8         0x8           -
                MR3         :       0x601           0           0           -
                MR5         :           -       0x400       0x400           -
                MR6         :           -       0x862       0x862           -
                TPR0        :         0x8           0           0           -
                TPR3        :       0x400           0           0           -
                TPR4        :       0x862           -           0           -
                TPR6        :           0      0xa000      0xa000           -
                TPR10       :           0    0x2f7777    0x2f7777           -
                TPR11       :           0   0xf101511   0xf101511           -
                TPR12       :           0   0xf0f1512   0xf0f1512           -
                TPR13       :           0      0x1d00      0x1d00           -
                TPR14       :           -           -  0x19191c1c           -
        DRAM parameters 7:            A64        H616        A133          H6
                DRAM clock  :       0x2d0       0x2d0       0x2d0           -
                DRAM type   :         0x3         0x3         0x3           -
                ZQ value    :   0x7070707           -           -           -
                ODT enabled :   0xc0c0c0c  0x15101212           -           -
                DX ODT      :           -   0x7070707   0x7070707           -
                DX DRI      :           -   0xc0c0c0c   0xc0c0c0c           -
                CA DRI      :           -       0xe0e       0xe0e           -
                PARA0       :           -           -  0x15101212           -
                PARA1       :       0xe0e      0x30fa      0x30fa           -
                PARA2       :  0x15101212           0           0           -
                MR0         :      0x30fa       0x840       0x840           -
                MR1         :           0         0x4         0x4           -
                MR2         :       0x840         0x8         0x8           -
                MR3         :         0x4           0           0           -
                TPR0        :         0x8           0           0           -
                TPR6        :           0  0x33808080  0x33808080           -
                TPR10       :           0    0x2f7458    0x2f7458           -
                TPR11       :           0   0xf0b0e0c   0xf0b0e0c           -
                TPR12       :           0  0x19191818  0x19191818           -
                TPR13       :           0        0x40        0x40           -
                TPR14       :           -           -  0x26232323           -
```

</details>